### PR TITLE
Old test data dependencies

### DIFF
--- a/tests/data/broken_1/setup.py
+++ b/tests/data/broken_1/setup.py
@@ -45,7 +45,7 @@ setup(
         "pywinusb==0.4.2; os_name == 'nt'",
         "pyyaml==3.12",
         "records==0.5.2",
-        "requests==2.18.4",
+        "requests==2.20.0",
         "sqlalchemy==1.1.14",
         "tablib==0.12.1",
         "unicodecsv==0.14.1",

--- a/tests/data/broken_1/setup.py
+++ b/tests/data/broken_1/setup.py
@@ -49,7 +49,7 @@ setup(
         "sqlalchemy==1.1.14",
         "tablib==0.12.1",
         "unicodecsv==0.14.1",
-        "urllib3==1.22",
+        "urllib3==1.24.2",
         "xlrd==1.1.0",
         "xlwt==1.3.0",
     ],  # Optional

--- a/tests/data/extra_0/setup.py
+++ b/tests/data/extra_0/setup.py
@@ -146,7 +146,7 @@ setup(
         "pywinusb==0.4.2; os_name == 'nt'",
         "pyyaml==3.12",
         "records==0.5.2",
-        "requests==2.18.4",
+        "requests==2.20.0",
         "sqlalchemy==1.1.14",
         "tablib==0.12.1",
         "unicodecsv==0.14.1",

--- a/tests/data/extra_0/setup.py
+++ b/tests/data/extra_0/setup.py
@@ -150,7 +150,7 @@ setup(
         "sqlalchemy==1.1.14",
         "tablib==0.12.1",
         "unicodecsv==0.14.1",
-        "urllib3==1.22",
+        "urllib3==1.24.2",
         "xlrd==1.1.0",
         "xlwt==1.3.0",
     ],  # Optional


### PR DESCRIPTION
# Summary

Some of the dependencies in the old test data packages had security vulnerabilities. GitHub's `dependabot` identified and updated the package specifications in the `tests` directory.