### PR TITLE
Bugfix: sync --pipfile congratulations message

### DIFF
--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -244,11 +244,12 @@ def sync(argv):
                 dependency_arguments[destination_kw].append(value)
 
         if only_setup_missing:
+            # TODO add test coverage for this branch
             print(msg_formatter.setup_not_found())
             print("Creating boilerplate setup.py...")
             setup_code = setup_filler.fill_boilerplate(dependency_arguments)
             if setup_code is None:
-                fatal_error("Can not find setup.py template file")
+                fatal_error("Cannot find setup.py template file")
             try:
                 with open(setup_file_path, "w") as new_setup_file:
                     new_setup_file.write(setup_code)
@@ -257,12 +258,9 @@ def sync(argv):
                 fatal_error([str(e), "failed to write setup.py file"])
             else:
                 congratulate(
-                    [
-                        "setup.py generated",
-                        "%d packages moved from %s to setup.py"
-                        % (default_package_success_count, file.name),
-                        "Please edit the required fields in the generated file",
-                    ]
+                    msg_formatter.generate_success(
+                        default_package_success_count, dev_package_success_count
+                    )
                 )
 
         else:  # all files exist. Update setup.py

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -244,7 +244,6 @@ def sync(argv):
                 dependency_arguments[destination_kw].append(value)
 
         if only_setup_missing:
-            # TODO add test coverage for this branch
             print(msg_formatter.setup_not_found())
             print("Creating boilerplate setup.py...")
             setup_code = setup_filler.fill_boilerplate(dependency_arguments)

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -250,7 +250,7 @@ def sync(argv):
             if setup_code is None:
                 fatal_error("Cannot find setup.py template file")
             try:
-                with open(setup_file_path, "w") as new_setup_file:
+                with open(str(setup_file_path), "w") as new_setup_file:
                     new_setup_file.write(setup_code)
                 format_file(setup_file_path)
             except OSError as e:

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -259,7 +259,9 @@ def sync(argv):
             else:
                 congratulate(
                     msg_formatter.generate_success(
-                        default_package_success_count, dev_package_success_count
+                        default_package_success_count,
+                        dev_package_success_count,
+                        argv.pipfile,
                     )
                 )
 
@@ -272,7 +274,9 @@ def sync(argv):
                 fatal_error([str(e), msg_formatter.no_sync_performed()])
             congratulate(
                 msg_formatter.update_success(
-                    default_package_success_count, dev_package_success_count
+                    default_package_success_count,
+                    dev_package_success_count,
+                    argv.pipfile,
                 )
             )
     else:

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -44,20 +44,23 @@ def checked_no_problem():
 
 
 def update_success(
-    default_package_count, dev_package_count=0
-):  # type: (int, int) -> str
+    default_package_count, dev_package_count=0, pipfile=False
+):  # type: (int, int, bool) -> str
     """
     :param default_package_count: The number of updated default packages
     :param dev_package_count: The number of updated dev packages
+    :param bool lockfile: indicate that Pipfile was used to update setup.py
     """
+    src = "Pipfile" if pipfile else "Pipfile.lock"
     string = (
         "setup.py successfully updated"
-        + "\n%d default packages from Pipfile.lock synced to setup.py"
-        % default_package_count
+        + "\n%d default packages from %s synced to setup.py"
+        % (default_package_count, src)
     )
+
     if dev_package_count != 0:
-        string += (
-            "\n%d dev packages from Pipfile.lock synced to setup.py"
-            % default_package_count
+        string += "\n%d dev packages from %s synced to setup.py" % (
+            default_package_count,
+            src,
         )
     return string

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -43,6 +43,29 @@ def checked_no_problem():
     return "No version conflict or missing packages/dependencies found in setup.py!"
 
 
+def generate_success(
+    default_package_count, dev_package_count=0, pipfile=False
+):  # type: (int, int, bool) -> str
+    """
+    :param default_package_count: The number of updated default packages
+    :param dev_package_count: The number of updated dev packages
+    :param bool lockfile: indicate that Pipfile was used to update setup.py
+    """
+    src = "Pipfile" if pipfile else "Pipfile.lock"
+    string = (
+        "setup.py generated"
+        "\n%d default packages moved from %s to setup.py" % (default_package_count, src)
+    )
+
+    if dev_package_count != 0:
+        string += "\n%d dev packages from %s synced to setup.py" % (
+            default_package_count,
+            src,
+        )
+
+    string += "\nPlease edit the required fields in the generated file"
+    return string
+
 def update_success(
     default_package_count, dev_package_count=0, pipfile=False
 ):  # type: (int, int, bool) -> str

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -53,7 +53,7 @@ def generate_success(
     """
     src = "Pipfile" if pipfile else "Pipfile.lock"
     string = (
-        "setup.py generated"
+        "setup.py was successfully generated"
         "\n%d default packages synced from %s to setup.py" % (default_package_count, src)
     )
 
@@ -76,7 +76,7 @@ def update_success(
     """
     src = "Pipfile" if pipfile else "Pipfile.lock"
     string = (
-        "setup.py successfully updated"
+        "setup.py was successfully updated"
         + "\n%d default packages from %s synced to setup.py"
         % (default_package_count, src)
     )

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -54,7 +54,7 @@ def generate_success(
     src = "Pipfile" if pipfile else "Pipfile.lock"
     string = (
         "setup.py generated"
-        "\n%d default packages moved from %s to setup.py" % (default_package_count, src)
+        "\n%d default packages synced from %s to setup.py" % (default_package_count, src)
     )
 
     if dev_package_count != 0:

--- a/tests/sync_pipfile_test.py
+++ b/tests/sync_pipfile_test.py
@@ -1,16 +1,55 @@
-from vistir.compat import Path
 from .conftest import data
+from .main_test import copy_file, compare_list_of_string_kw_arg
 from pipenv_setup.main import cmd
 
+import pytest
+from vistir.compat import Path
 
-def test_sync_dev_no_original(tmp_path):
+
+@pytest.mark.parametrize(
+    ("source_pipfile_dirname", "update_count"),
+    [("nasty_0", 23), ("no_original_kws_0", 23)],
+)
+def test_sync_pipfile_no_original(
+    capsys, tmp_path, shared_datadir, source_pipfile_dirname, update_count
+):
     """
-    sync --dev should add extras_require: {"dev": [blah]} in the absence of a extras_require keyword
+    sync --pipfile should reference Pipfile (not Pipfile.lock) when printing results
+    """
+    pipfile_dir = shared_datadir / source_pipfile_dirname
+    for filename in ("Pipfile", "Pipfile.lock", "setup.py"):
+        copy_file(pipfile_dir / filename, tmp_path)
+
+    with data(pipfile_dir, tmp_path) as path:
+        setup_file = path / "setup.py"  # type: Path
+        cmd(["", "sync", "--pipfile"])
+        text = setup_file.read_text()
+        generated_setup = Path("setup.py")
+        assert generated_setup.exists()
+        generated_setup_text = generated_setup.read_text()
+        expected_setup_text = Path("setup.py").read_text()
+
+    for kw_arg_names in ("install_requires", "dependency_links"):
+        assert compare_list_of_string_kw_arg(
+            generated_setup_text,
+            expected_setup_text,
+            kw_arg_names,
+            ordering_matters=False,
+        )
+
+    captured = capsys.readouterr()
+    assert "Pipfile.lock" not in captured.out, captured.out
+
+
+def test_sync_dev_pipfile_no_original(tmp_path):
+    """
+    sync --dev --pipfile should add extras_require: {"dev": [blah]} in the absence of an
+    extras_require keyword
     """
     # todo: this test is too simple
     with data("self_0", tmp_path) as path:
         setup_file = path / "setup.py"  # type: Path
         cmd(["", "sync", "--dev", "--pipfile"])
         text = setup_file.read_text()
-        assert "pytest~=5.1" in text
-        assert "requirementslib~=1.5" in text
+        assert "pytest~=5.1" in text, text
+        assert "requirementslib~=1.5" in text, text

--- a/tests/sync_pipfile_test.py
+++ b/tests/sync_pipfile_test.py
@@ -20,7 +20,7 @@ def test_sync_pipfile_no_original(
     for filename in ("Pipfile", "Pipfile.lock", "setup.py"):
         copy_file(pipfile_dir / filename, tmp_path)
 
-    with data(pipfile_dir, tmp_path) as path:
+    with data(str(pipfile_dir), tmp_path) as path:
         setup_file = path / "setup.py"  # type: Path
         cmd(["", "sync", "--pipfile"])
         text = setup_file.read_text()

--- a/tests/sync_pipfile_test.py
+++ b/tests/sync_pipfile_test.py
@@ -39,6 +39,7 @@ def test_sync_pipfile_no_original(
 
     captured = capsys.readouterr()
     assert "Pipfile.lock" not in captured.out, captured.out
+    assert "Pipfile" in captured.out, captured.out
 
 
 def test_sync_dev_pipfile_no_original(tmp_path):


### PR DESCRIPTION
# Summary

Previously, `pipenv-setup sync --pipfile` displayed the message **n** *(default|dev) packages synced from Pipfile.lock*. This has been updated to print `Pipfile` instead of `Pipfile.lock` as appropriate.

Also added a test case for missing `setup.py` to increase code coverage a little.