### PR TITLE
Fix Tests on Windows and MacOS

### DIFF
--- a/.idea/dictionaries/Matt.xml
+++ b/.idea/dictionaries/Matt.xml
@@ -1,7 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="Matt">
-    <words>
-      <w>pytest</w>
-    </words>
-  </dictionary>
-</component>

--- a/.idea/dictionaries/Matt.xml
+++ b/.idea/dictionaries/Matt.xml
@@ -1,7 +1,7 @@
 <component name="ProjectDictionaryState">
-  <dictionary name="matt">
+  <dictionary name="Matt">
     <words>
-      <w>autopep</w>
+      <w>pytest</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/dictionaries/matt.xml
+++ b/.idea/dictionaries/matt.xml
@@ -1,7 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="Matt">
-    <words>
-      <w>pytest</w>
-    </words>
-  </dictionary>
-</component>

--- a/.idea/dictionaries/matt.xml
+++ b/.idea/dictionaries/matt.xml
@@ -1,7 +1,7 @@
 <component name="ProjectDictionaryState">
-  <dictionary name="matt">
+  <dictionary name="Matt">
     <words>
-      <w>autopep</w>
+      <w>pytest</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -21,8 +21,5 @@
       <option name="workingDir" value="$ProjectFileDir$" />
       <envs />
     </TaskOptions>
-    <enabled-global>
-      <option value="black" />
-    </enabled-global>
   </component>
 </project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,9 @@ jobs:
     os: osx
     osx_image: xcode9.3  # Python 2.7.14_2 running on macOS 10.13
     language: shell
+    before_install:
+      - python -m pip install --user --upgrade pip
+      - python -m pip install --user --upgrade setuptools
     install: python -m pip install --user tox-travis
     script: python -m tox -e py27
     before_script: python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.8-dev
-      - pyenv global 3.8-dev
+      - pyenv global system 3.8-dev
     # end switch
     install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py38
@@ -63,7 +63,7 @@ jobs:
     before_script: python3 --version
     language: shell
     install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py36
+    script: python3 -m tox -e py
 
   # osx python 3.5
   - name: "Python: 3.5"
@@ -80,7 +80,7 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.5.2
-      - pyenv global 3.5.2
+      - pyenv global system 3.5.2
     # end switch
     install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py35
@@ -100,7 +100,7 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.4.5
-      - pyenv global 3.4.5
+      - pyenv global system 3.4.5
       - python3 -m pip install --user --upgrade setuptools
     # end switch
     install: python3 -m pip install --user .[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ jobs:
       - pyenv install 3.5.2
       - pyenv global 3.5.2
       - export PATH="/Users/travis/.pyenv/shims:${PATH}"
+      - python3 -m pip install --user --upgrade pip
+      - python3 -m pip install --user --upgrade setuptools
     # end switch
     install: python3 -m pip install --user .[dev]
     # for some reason tox cannot find python3.5. we have to use py instead of py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,11 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.5.2
-      - pyenv global 3.5.2 system
+      - pyenv global 3.5.2
     # end switch
-    install: python3.5 -m pip install --user .[dev]
-    script: python3.5 -m tox -e py35
+    install: python3 -m pip install --user .[dev]
+    # for some reason tox cannot find python3.5. we have to use py instead of py35
+    script: python3 -m tox -e py
 
   # osx python 3.4
   - name: "Python: 3.4"
@@ -100,11 +101,14 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.4.5
-      - pyenv global 3.4.5 system
-      - python3.4 -m pip install --user --upgrade setuptools
+      - pyenv global 3.4.5
+      - python3 -m pip install --user pip==19.1
+      - python3 -m pip install --user --upgrade setuptools
     # end switch
-    install: python3.4 -m pip install --user .[dev]
-    script: python3.4 -m tox -e py34
+    install:
+      - python3 -m pip install --user .[dev]
+      - python3 -m pip install --user pytest~=4.6
+    script: python3 -m tox -e py
 
   # osx python 2.7.14
   - name: "Python: 2.7.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,11 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.8-dev
-      - pyenv global 3.8-dev
+      - pyenv global 3.8
+      - export PATH="/Users/travis/.pyenv/shims:${PATH}"
     # end switch
     install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py
+    script: python3 -m tox -e py38
 
   # osx python 3.7
   - name: "Python: 3.7"
@@ -81,10 +82,11 @@ jobs:
     before_install:
       - pyenv install 3.5.2
       - pyenv global 3.5.2
+      - export PATH="/Users/travis/.pyenv/shims:${PATH}"
     # end switch
     install: python3 -m pip install --user .[dev]
     # for some reason tox cannot find python3.5. we have to use py instead of py35
-    script: python3 -m tox -e py
+    script: python3 -m tox -e py35
 
   # osx python 3.4
   - name: "Python: 3.4"
@@ -102,13 +104,12 @@ jobs:
     before_install:
       - pyenv install 3.4.5
       - pyenv global 3.4.5
-      - python3 -m pip install --user pip==19.1
+      - export PATH="/Users/travis/.pyenv/shims:${PATH}"
+      - python3 -m pip install --user pip==19.1 # highest pip support for python 3.4 is 19.1
       - python3 -m pip install --user --upgrade setuptools
     # end switch
-    install:
-      - python3 -m pip install --user .[dev]
-      - python3 -m pip install --user pytest~=4.6
-    script: python3 -m tox -e py
+    install: python3 -m pip install --user .[dev]
+    script: python3 -m tox -e py34
 
   # osx python 2.7.14
   - name: "Python: 2.7.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     script: python3 -m tox -e py34
   - python: '2.7.17'
     install: python -m pip install .[dev]
-    script: 'python -m tox -e py27'
+    script: python -m tox -e py27
 
   # osx python 3.8
   - name: "Python: 3.8"
@@ -63,7 +63,7 @@ jobs:
     before_script: python3 --version
     language: shell
     install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py
+    script: python3 -m tox -e py36
 
   # osx python 3.5
   - name: "Python: 3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.8-dev
-      - pyenv global 3.8
+      - pyenv global 3.8-dev
       - export PATH="/Users/travis/.pyenv/shims:${PATH}"
     # end switch
     install: python3 -m pip install --user .[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ jobs:
     before_install:
       - pyenv install 3.4.5
       - pyenv global 3.4.5
+      - python3 -m pip install --user --upgrade setuptools
     install: python3 -m pip install --user tox-travis
     # end switch
     script: python3 -m tox -e py34
@@ -172,6 +173,7 @@ jobs:
     before_install:
       - choco install python --version 3.4.4.20180111
       - python -m pip install --upgrade pip
+      - python -m pip install --upgrade setuptools # old setuptools does not recognize a bunch of keyword arguments in setup.py
     install: python -m pip install tox-travis
     script: python -m tox -e py34
     env: PATH=/c/Python34:/c/Python34/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ dist: xenial
 
 # only intended for Linux python3 jobs.
 install: python3 -m pip install tox-travis
-# only intended for Linux and Mac python3 jobs. Windows will overwrite
+# only intended for Linux python3 jobs.
+# Windows and MacOS will overwrite (Partly as tox-travis does not work on these two platforms)
+# https://github.com/tox-dev/tox-travis/issues/133
 script: python3 -m tox
 
 
@@ -40,42 +42,28 @@ jobs:
       - pyenv global 3.8-dev
     install: python3 -m pip install --user tox-travis
     # end switch
+    script: python3 -m tox -e py38
 
   # osx python 3.7
   - name: "Python: 3.7"
     os: osx
     # xcode 11 image comes with python 3.7
     osx_image: xcode11
-    cache:
-      directories:
-        - $HOME/Library/Caches/Homebrew
-        - /usr/local/Homebrew
     # language: python will error
     language: shell
-    addons:
-      homebrew:
-        update: true
+    before_script: python3 --version
     # weird permission error without --user
     install: python3 -m pip install --user tox-travis
+    script: python3 -m tox -e py37
 
-  # osx python 3.6
-  - name: "Python: 3.6"
+  # osx python 3.6.5
+  - name: "Python: 3.6.5"
     os: osx
-    cache:
-      directories:
-        - $HOME/Library/Caches/Homebrew
-        - /usr/local/Homebrew
-    osx_image: xcode11
+    osx_image: xcode9.4 # Python 3.6.5 running on macOS 10.13
+    before_script: python3 --version
     language: shell
-    addons:
-      homebrew:
-        update: true
-    # switch to python 3.6
-    before_install:
-      - pyenv install 3.6.5
-      - pyenv global 3.6.5
     install: python3 -m pip install --user tox-travis
-    # end switch
+    script: python3 -m tox -e py36
 
   # osx python 3.5
   - name: "Python: 3.5"
@@ -95,6 +83,7 @@ jobs:
       - pyenv global 3.5.2
     install: python3 -m pip install --user tox-travis
     # end switch
+    script: python3 -m tox -e py35
 
   # osx python 3.4
   - name: "Python: 3.4"
@@ -114,26 +103,17 @@ jobs:
       - pyenv global 3.4.5
     install: python3 -m pip install --user tox-travis
     # end switch
+    script: python3 -m tox -e py34
 
-  # osx python 2.7.12
-  - name: "Python: 2.7"
+  # osx python 2.7.14
+  - name: "Python: 2.7.14"
     os: osx
-    osx_image: xcode11
-    cache:
-      directories:
-        - $HOME/Library/Caches/Homebrew
-        - /usr/local/Homebrew
+    osx_image: xcode9.3  # Python 2.7.14_2 running on macOS 10.13
     language: shell
-    # switch to python 2.7
-    addons:
-      homebrew:
-        update: true
-    before_install:
-      - pyenv install 2.7.12
-      - pyenv global 2.7.12
     install: python -m pip install --user tox-travis
-    script: python -m tox
+    script: python -m tox -e py27
     # end switch
+    before_script: python3 --version
 
   # windows python 3.8
   - name: "Python: 3.8"
@@ -146,7 +126,7 @@ jobs:
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
     # On Windows, python3 does not exist
-    script: python -m tox
+    script: python -m tox -e py38
     env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 
   # windows python 3.7
@@ -160,7 +140,7 @@ jobs:
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
     # On Windows, python3 does not exist
-    script: python -m tox
+    script: python -m tox -e py37
     env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
   # windows python 3.6
@@ -171,7 +151,7 @@ jobs:
       - choco install python --version 3.6.8
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
-    script: python -m tox
+    script: python -m tox -e py36
     env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
 
   # windows python 3.5
@@ -182,7 +162,7 @@ jobs:
       - choco install python --version 3.5.4
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
-    script: python -m tox
+    script: python -m tox -e py35
     env: PATH=/c/Python35:/c/Python35/Scripts:$PATH
 
   # windows python 3.4
@@ -193,7 +173,7 @@ jobs:
       - choco install python --version 3.4.4.20180111
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
-    script: python -m tox
+    script: python -m tox -e py34
     env: PATH=/c/Python34:/c/Python34/Scripts:$PATH
 
   # windows python 2.7
@@ -204,5 +184,5 @@ jobs:
       - choco install python2
       - python -m pip install --upgrade pip
     install: python -m pip install tox-travis
-    script: python -m tox
+    script: python -m tox -e py27
     env: PATH=/c/Python27:/c/Python27/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ jobs:
     before_install:
       - pyenv install 3.8-dev
       - pyenv global 3.8-dev
-    install: python3 -m pip install --user tox-travis
     # end switch
     script: python3 -m tox -e py38
 
@@ -52,8 +51,6 @@ jobs:
     # language: python will error
     language: shell
     before_script: python3 --version
-    # weird permission error without --user
-    install: python3 -m pip install --user tox-travis
     script: python3 -m tox -e py37
 
   # osx python 3.6.5
@@ -62,7 +59,6 @@ jobs:
     osx_image: xcode9.4 # Python 3.6.5 running on macOS 10.13
     before_script: python3 --version
     language: shell
-    install: python3 -m pip install --user tox-travis
     script: python3 -m tox -e py36
 
   # osx python 3.5
@@ -81,7 +77,6 @@ jobs:
     before_install:
       - pyenv install 3.5.2
       - pyenv global 3.5.2
-    install: python3 -m pip install --user tox-travis
     # end switch
     script: python3 -m tox -e py35
 
@@ -102,7 +97,6 @@ jobs:
       - pyenv install 3.4.5
       - pyenv global 3.4.5
       - python3 -m pip install --user --upgrade setuptools
-    install: python3 -m pip install --user tox-travis
     # end switch
     script: python3 -m tox -e py34
 
@@ -114,7 +108,6 @@ jobs:
     before_install:
       - python -m pip install --user --upgrade pip
       - python -m pip install --user --upgrade setuptools
-    install: python -m pip install --user tox-travis
     script: python -m tox -e py27
     before_script: python --version
 
@@ -127,7 +120,6 @@ jobs:
     before_install:
       - choco install python --version 3.8.0
       - python -m pip install --upgrade pip
-    install: python -m pip install tox-travis
     # On Windows, python3 does not exist
     script: python -m tox -e py38
     env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
@@ -141,7 +133,6 @@ jobs:
     before_install:
       - choco install python --version 3.7.4
       - python -m pip install --upgrade pip
-    install: python -m pip install tox-travis
     # On Windows, python3 does not exist
     script: python -m tox -e py37
     env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
@@ -153,7 +144,6 @@ jobs:
     before_install:
       - choco install python --version 3.6.8
       - python -m pip install --upgrade pip
-    install: python -m pip install tox-travis
     script: python -m tox -e py36
     env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
 
@@ -164,7 +154,6 @@ jobs:
     before_install:
       - choco install python --version 3.5.4
       - python -m pip install --upgrade pip
-    install: python -m pip install tox-travis
     script: python -m tox -e py35
     env: PATH=/c/Python35:/c/Python35/Scripts:$PATH
 
@@ -176,7 +165,6 @@ jobs:
       - choco install python --version 3.4.4.20180111
       - python -m pip install --upgrade pip
       - python -m pip install --upgrade setuptools # old setuptools does not recognize a bunch of keyword arguments in setup.py
-    install: python -m pip install tox-travis
     script: python -m tox -e py34
     env: PATH=/c/Python34:/c/Python34/Scripts:$PATH
 
@@ -187,6 +175,5 @@ jobs:
     before_install:
       - choco install python2
       - python -m pip install --upgrade pip
-    install: python -m pip install tox-travis
     script: python -m tox -e py27
     env: PATH=/c/Python27:/c/Python27/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: python
 dist: xenial
 
 # only intended for Linux python3 jobs.
-install: python3 -m pip install tox-travis
-# only intended for Linux python3 jobs.
-# Windows and MacOS will overwrite (Partly as tox-travis does not work on these two platforms)
-# https://github.com/tox-dev/tox-travis/issues/133
-script: python3 -m tox
+# Linux Python2.7 job, Windows jobs, and Mac jobs will overwrite
+install: python3 -m pip install .[dev]
 
 
 before_cache:
@@ -16,13 +13,18 @@ jobs:
   include:
   # linux
   - python: '3.8'
+    script: python3 -m tox -e py38
   - python: '3.7'
+    script: python3 -m tox -e py37
   - python: '3.6.9'
+    script: python3 -m tox -e py36
   - python: '3.5'
+    script: python3 -m tox -e py35
   - python: '3.4.8'
+    script: python3 -m tox -e py34
   - python: '2.7.17'
-    install: 'python -m pip install tox-travis'
-    script: 'python -m tox'
+    install: python -m pip install .[dev]
+    script: 'python -m tox -e py27'
 
   # osx python 3.8
   - name: "Python: 3.8"
@@ -41,6 +43,7 @@ jobs:
       - pyenv install 3.8-dev
       - pyenv global 3.8-dev
     # end switch
+    install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py38
 
   # osx python 3.7
@@ -50,7 +53,7 @@ jobs:
     osx_image: xcode11
     # language: python will error
     language: shell
-    before_script: python3 --version
+    install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py37
 
   # osx python 3.6.5
@@ -59,6 +62,7 @@ jobs:
     osx_image: xcode9.4 # Python 3.6.5 running on macOS 10.13
     before_script: python3 --version
     language: shell
+    install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py36
 
   # osx python 3.5
@@ -78,6 +82,7 @@ jobs:
       - pyenv install 3.5.2
       - pyenv global 3.5.2
     # end switch
+    install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py35
 
   # osx python 3.4
@@ -98,6 +103,7 @@ jobs:
       - pyenv global 3.4.5
       - python3 -m pip install --user --upgrade setuptools
     # end switch
+    install: python3 -m pip install --user .[dev]
     script: python3 -m tox -e py34
 
   # osx python 2.7.14
@@ -108,8 +114,8 @@ jobs:
     before_install:
       - python -m pip install --user --upgrade pip
       - python -m pip install --user --upgrade setuptools
+    install: python -m pip install --user .[dev]
     script: python -m tox -e py27
-    before_script: python --version
 
   # windows python 3.8
   - name: "Python: 3.8"
@@ -120,6 +126,7 @@ jobs:
     before_install:
       - choco install python --version 3.8.0
       - python -m pip install --upgrade pip
+    install: python -m pip install --user .[dev]
     # On Windows, python3 does not exist
     script: python -m tox -e py38
     env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
@@ -133,6 +140,7 @@ jobs:
     before_install:
       - choco install python --version 3.7.4
       - python -m pip install --upgrade pip
+    install: python -m pip install --user .[dev]
     # On Windows, python3 does not exist
     script: python -m tox -e py37
     env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
@@ -144,6 +152,7 @@ jobs:
     before_install:
       - choco install python --version 3.6.8
       - python -m pip install --upgrade pip
+    install: python -m pip install --user .[dev]
     script: python -m tox -e py36
     env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
 
@@ -154,6 +163,7 @@ jobs:
     before_install:
       - choco install python --version 3.5.4
       - python -m pip install --upgrade pip
+    install: python -m pip install --user .[dev]
     script: python -m tox -e py35
     env: PATH=/c/Python35:/c/Python35/Scripts:$PATH
 
@@ -165,6 +175,7 @@ jobs:
       - choco install python --version 3.4.4.20180111
       - python -m pip install --upgrade pip
       - python -m pip install --upgrade setuptools # old setuptools does not recognize a bunch of keyword arguments in setup.py
+    install: python -m pip install --user .[dev]
     script: python -m tox -e py34
     env: PATH=/c/Python34:/c/Python34/Scripts:$PATH
 
@@ -175,5 +186,6 @@ jobs:
     before_install:
       - choco install python2
       - python -m pip install --upgrade pip
+    install: python -m pip install --user .[dev]
     script: python -m tox -e py27
     env: PATH=/c/Python27:/c/Python27/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,7 @@ jobs:
     language: shell
     install: python -m pip install --user tox-travis
     script: python -m tox -e py27
-    # end switch
-    before_script: python3 --version
+    before_script: python --version
 
   # windows python 3.8
   - name: "Python: 3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.8-dev
-      - pyenv global 3.8-dev system
+      - pyenv global 3.8-dev
     # end switch
-    install: python3.8 -m pip install --user .[dev]
-    script: python3.8 -m tox -e py38
+    install: python3 -m pip install --user .[dev]
+    script: python3 -m tox -e py
 
   # osx python 3.7
   - name: "Python: 3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.8-dev
-      - pyenv global system 3.8-dev
+      - pyenv global 3.8-dev system
     # end switch
-    install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py38
+    install: python3.8 -m pip install --user .[dev]
+    script: python3.8 -m tox -e py38
 
   # osx python 3.7
   - name: "Python: 3.7"
@@ -80,10 +80,10 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.5.2
-      - pyenv global system 3.5.2
+      - pyenv global 3.5.2 system
     # end switch
-    install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py35
+    install: python3.5 -m pip install --user .[dev]
+    script: python3.5 -m tox -e py35
 
   # osx python 3.4
   - name: "Python: 3.4"
@@ -100,11 +100,11 @@ jobs:
         update: true
     before_install:
       - pyenv install 3.4.5
-      - pyenv global system 3.4.5
-      - python3 -m pip install --user --upgrade setuptools
+      - pyenv global 3.4.5 system
+      - python3.4 -m pip install --user --upgrade setuptools
     # end switch
-    install: python3 -m pip install --user .[dev]
-    script: python3 -m tox -e py34
+    install: python3.4 -m pip install --user .[dev]
+    script: python3.4 -m tox -e py34
 
   # osx python 2.7.14
   - name: "Python: 2.7.14"
@@ -173,7 +173,7 @@ jobs:
     language: shell
     before_install:
       - choco install python --version 3.4.4.20180111
-      - python -m pip install --upgrade pip
+      - python -m pip install pip==19.1
       - python -m pip install --upgrade setuptools # old setuptools does not recognize a bunch of keyword arguments in setup.py
     install: python -m pip install --user .[dev]
     script: python -m tox -e py34

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,13 +74,15 @@ Please use package entry instead: `python3 -m pipenv_setup sync --dev --pipfile`
 
 # Tests
 
-`$ pytest` runs all the tests with your python version
+`$ pytest` runs tests with your python version
 
 Optionally, if you have some of python 2.7/3.4/3.5/3.6/3.7/3.8 installed
 
 `$ tox` will run tests on at most 6 python versions depending how many versions you installed on your machine
 
-Specify `$ tox -e pyXX` to run tests with specific python version
+Specify `$ tox -e pyXX` to run tests with specific python version. It's worth noting `py37` is the major test environment 
+and has extra `mypy` tests for static type checking (if type hints are used in code). For lightweight tests, it's a good
+ choice is to at least have python3.7 and use `$ tox -e py37` instead of `$ pytest`
 
 In this project, dev dependencies in Pipfile should be synced to `setup.py` in `extras_require`, as tox installs 
 `pipenv-setup[dev]` before running tests.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,6 @@ pytest-datadir = "~=1.3"
 codecov = {markers = "python_version>='3.6'",version = "~=2.0"}
 pytest-xdist = "~=1.29"
 tox = "~=3.14"
-tox-travis = "~=0.12"
 autopep8 = "~=1.4"
 
 [packages]

--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,7 @@ requirementslib = "~=1.5"
 vistir = "~=0.4"
 autopep8 = {markers = "python_version<'3.6'",version = "~=1.4"}
 six = "~=1.12"
+typing = "~=3.7"
 
 [scripts]
 # use this to sync this pipfile to setup.py, explained in CONTRIBUTING.md

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0ba195fd4826a439c0c1d57988a378f6a113006dd11ace07cfea11034e44cec0"
+            "sha256": "a0f4882cf3579a584340017ba31d9513bfeaf1858b538f48168b8837e0d17553"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -701,14 +701,6 @@
             ],
             "index": "pypi",
             "version": "==3.14.1"
-        },
-        "tox-travis": {
-            "hashes": [
-                "sha256:442c96b078333c94e272d0e90e4582e35e0529ea98bcd2f7f96053d690c4e7a4",
-                "sha256:465cd8f71ad878962a3fce0e9e2e213994e0ae4e0c30f87fe6af1b04ea282dc4"
-            ],
-            "index": "pypi",
-            "version": "==0.12"
         },
         "typed-ast": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -736,6 +736,15 @@
             ],
             "version": "==1.4.0"
         },
+        "typing": {
+            "hashes": [
+                "sha256:91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23",
+                "sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36",
+                "sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"
+            ],
+            "index": "pypi",
+            "version": "==3.7.4.1"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a0f4882cf3579a584340017ba31d9513bfeaf1858b538f48168b8837e0d17553"
+            "sha256": "82163dbae0a5bd5a998fd9371b7fd5ce0a9bcf60b6d2d7723d47a01cd8515058"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -266,6 +266,15 @@
                 "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
             "version": "==1.4.0"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23",
+                "sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36",
+                "sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"
+            ],
+            "index": "pypi",
+            "version": "==3.7.4.1"
         },
         "urllib3": {
             "hashes": [

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -3,7 +3,15 @@ from __future__ import print_function
 import argparse
 import sys
 from sys import stderr
-from typing import List, Union, NoReturn, Iterable, Text
+from typing import List, Union, Iterable, Text
+
+try:
+    # Seems like NoReturn is not backported properly in python 3.5
+    # build failure
+    # https://travis-ci.org/Madoshakalaka/pipenv-setup/jobs/613058915?utm_medium=notification&utm_source=github_status
+    from typing import NoReturn
+except ImportError:
+    pass
 
 from six import string_types
 

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -43,20 +43,49 @@ def checked_no_problem():
     return "No version conflict or missing packages/dependencies found in setup.py!"
 
 
-def update_success(
-    default_package_count, dev_package_count=0
-):  # type: (int, int) -> str
+def generate_success(
+    default_package_count, dev_package_count=0, pipfile=False
+):  # type: (int, int, bool) -> str
     """
     :param default_package_count: The number of updated default packages
     :param dev_package_count: The number of updated dev packages
+    :param bool lockfile: indicate that Pipfile was used to update setup.py
     """
+    src = "Pipfile" if pipfile else "Pipfile.lock"
     string = (
-        "setup.py successfully updated"
-        + "\n%d default packages from Pipfile.lock synced to setup.py"
-        % default_package_count
+        "setup.py was successfully generated"
+        "\n%d default packages synced from %s to setup.py"
+        % (default_package_count, src)
     )
+
     if dev_package_count != 0:
-        string += (
-            "\n%d dev packages from Pipfile.lock synced to setup.py" % dev_package_count
+        string += "\n%d dev packages from %s synced to setup.py" % (
+            default_package_count,
+            src,
+        )
+
+    string += "\nPlease edit the required fields in the generated file"
+    return string
+
+
+def update_success(
+    default_package_count, dev_package_count=0, pipfile=False
+):  # type: (int, int, bool) -> str
+    """
+    :param default_package_count: The number of updated default packages
+    :param dev_package_count: The number of updated dev packages
+    :param bool lockfile: indicate that Pipfile was used to update setup.py
+    """
+    src = "Pipfile" if pipfile else "Pipfile.lock"
+    string = (
+        "setup.py was successfully updated"
+        + "\n%d default packages from %s synced to setup.py"
+        % (default_package_count, src)
+    )
+
+    if dev_package_count != 0:
+        string += "\n%d dev packages from %s synced to setup.py" % (
+            dev_package_count,
+            src,
         )
     return string

--- a/pipenv_setup/msg_formatter.py
+++ b/pipenv_setup/msg_formatter.py
@@ -2,8 +2,8 @@
 All kinds of messages pipenv-setup prints to console
 """
 
-from vistir.compat import Path
 from colorama import Fore
+from vistir.compat import Path
 
 
 def colorful_help():
@@ -57,7 +57,6 @@ def update_success(
     )
     if dev_package_count != 0:
         string += (
-            "\n%d dev packages from Pipfile.lock synced to setup.py"
-            % default_package_count
+            "\n%d dev packages from Pipfile.lock synced to setup.py" % dev_package_count
         )
     return string

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2.2.4",  # Required
+    version="2.2.3",  # Required
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
@@ -122,7 +122,6 @@ setup(
         # And include any *.msg files found in the 'hello' package, too:
         "pipenv_setup": ["res/*"]
     },
-    data_files=[("", ["LICENSE"])],
     packages=find_packages(exclude=["tests", "docs"]),  # Required
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2.2.3",  # Required
+    version="2.2.4",  # Required
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ setup(
         "vistir~=0.4",
         "autopep8~=1.4; python_version < '3.6'",
         "six~=1.12",
+        "typing~=3.7",
     ],  # Optional
     entry_points={
         "console_scripts": ["pipenv-setup=pipenv_setup.main:cmd"]

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(
             "codecov~=2.0; python_version >= '3.6'",
             "pytest-xdist~=1.29",
             "tox~=3.14",
-            "tox-travis~=0.12",
             "autopep8~=1.4",
         ]
     },

--- a/tox.ini
+++ b/tox.ini
@@ -2,19 +2,12 @@
 envlist = py27, py34, py35, py36, py37, py38
 skip_missing_interpreters=true
 
-
 [testenv]
 extras = dev
 ; installed via setup[dev]
 whitelist_externals =
     pytest
     codecov
-passenv =
-    CI
-    TRAVIS
-    TRAVIS_*
-    TOXENV
-    CODECOV_*
 
 commands =
     pytest --cov=pipenv_setup {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py27, py34, py35, py36, py37, py38
 skip_missing_interpreters=true
 
 [testenv]
+passenv =
+    CODECOV_*
 extras = dev
 ; installed via setup[dev]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ whitelist_externals =
 commands =
     pytest --cov=pipenv_setup {posargs}
 
-
 [testenv:py34]
 ; pytest 5 doesn't exist
 deps =


### PR DESCRIPTION
- Use python built-into specific macOS images instead of always using pyenv.

- Fixed tests on Windows and MacOS

fixes #9 