### PR TITLE
Codecov to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 dist: xenial
+after_success: codecov
 
 # only intended for Linux python3 jobs.
 # Linux Python2.7 job, Windows jobs, and Mac jobs will overwrite

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ after_success: codecov
 
 # only intended for Linux python3 jobs.
 # Linux Python2.7 job, Windows jobs, and Mac jobs will overwrite
-install: python3 -m pip install .[dev]
-
+install: python3 -m pip install .[dev] codecov
 
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
@@ -45,7 +44,7 @@ jobs:
       - pyenv global 3.8-dev
       - export PATH="/Users/travis/.pyenv/shims:${PATH}"
     # end switch
-    install: python3 -m pip install --user .[dev]
+    install: python3 -m pip install --user .[dev] codecov
     script: python3 -m tox -e py38
 
   # osx python 3.7
@@ -55,7 +54,7 @@ jobs:
     osx_image: xcode11
     # language: python will error
     language: shell
-    install: python3 -m pip install --user .[dev]
+    install: python3 -m pip install --user .[dev] codecov
     script: python3 -m tox -e py37
 
   # osx python 3.6.5
@@ -64,7 +63,7 @@ jobs:
     osx_image: xcode9.4 # Python 3.6.5 running on macOS 10.13
     before_script: python3 --version
     language: shell
-    install: python3 -m pip install --user .[dev]
+    install: python3 -m pip install --user .[dev] codecov
     script: python3 -m tox -e py36
 
   # osx python 3.5
@@ -87,7 +86,7 @@ jobs:
       - python3 -m pip install --user --upgrade pip
       - python3 -m pip install --user --upgrade setuptools
     # end switch
-    install: python3 -m pip install --user .[dev]
+    install: python3 -m pip install --user .[dev] codecov
     # for some reason tox cannot find python3.5. we have to use py instead of py35
     script: python3 -m tox -e py35
 
@@ -111,7 +110,7 @@ jobs:
       - python3 -m pip install --user pip==19.1 # highest pip support for python 3.4 is 19.1
       - python3 -m pip install --user --upgrade setuptools
     # end switch
-    install: python3 -m pip install --user .[dev]
+    install: python3 -m pip install --user .[dev] codecov
     script: python3 -m tox -e py34
 
   # osx python 2.7.14
@@ -122,7 +121,7 @@ jobs:
     before_install:
       - python -m pip install --user --upgrade pip
       - python -m pip install --user --upgrade setuptools
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     script: python -m tox -e py27
 
   # windows python 3.8
@@ -134,7 +133,7 @@ jobs:
     before_install:
       - choco install python --version 3.8.0
       - python -m pip install --upgrade pip
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     # On Windows, python3 does not exist
     script: python -m tox -e py38
     env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
@@ -148,7 +147,7 @@ jobs:
     before_install:
       - choco install python --version 3.7.4
       - python -m pip install --upgrade pip
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     # On Windows, python3 does not exist
     script: python -m tox -e py37
     env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
@@ -160,7 +159,7 @@ jobs:
     before_install:
       - choco install python --version 3.6.8
       - python -m pip install --upgrade pip
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     script: python -m tox -e py36
     env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
 
@@ -171,7 +170,7 @@ jobs:
     before_install:
       - choco install python --version 3.5.4
       - python -m pip install --upgrade pip
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     script: python -m tox -e py35
     env: PATH=/c/Python35:/c/Python35/Scripts:$PATH
 
@@ -183,7 +182,7 @@ jobs:
       - choco install python --version 3.4.4.20180111
       - python -m pip install pip==19.1
       - python -m pip install --upgrade setuptools # old setuptools does not recognize a bunch of keyword arguments in setup.py
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     script: python -m tox -e py34
     env: PATH=/c/Python34:/c/Python34/Scripts:$PATH
 
@@ -194,6 +193,6 @@ jobs:
     before_install:
       - choco install python2
       - python -m pip install --upgrade pip
-    install: python -m pip install --user .[dev]
+    install: python -m pip install --user .[dev] codecov
     script: python -m tox -e py27
     env: PATH=/c/Python27:/c/Python27/Scripts:$PATH

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ pytest = {markers = "python_version>='3.6'",version = "~=5.2"}
 pytest-mypy = {markers = "python_version>='3.5'",version = "~=0.3"}
 pytest-cov = "~=2.7"
 pytest-datadir = "~=1.3"
-codecov = {markers = "python_version>='3.6'",version = "~=2.0"}
 pytest-xdist = "~=1.29"
 tox = "~=3.14"
 autopep8 = "~=1.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "82163dbae0a5bd5a998fd9371b7fd5ce0a9bcf60b6d2d7723d47a01cd8515058"
+            "sha256": "9e4ea089cc5194e01a7ab7eea7f74c5055044f383b4ace73a1b7de7990fff986"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -385,15 +385,6 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
-        },
-        "codecov": {
-            "hashes": [
-                "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
-                "sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.15"
         },
         "colorama": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,6 @@ setup(
             "pytest-mypy~=0.3; python_version >= '3.5'",
             "pytest-cov~=2.7",
             "pytest-datadir~=1.3",
-            "codecov~=2.0; python_version >= '3.6'",
             "pytest-xdist~=1.29",
             "tox~=3.14",
             "autopep8~=1.4",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = py27, py34, py35, py36, py37, py38
 skip_missing_interpreters=true
 
 [testenv]
-passenv =
-    CODECOV_*
 extras = dev
 ; installed via setup[dev]
 whitelist_externals =
@@ -12,6 +10,7 @@ whitelist_externals =
     codecov
 
 commands =
+    ; tip: tox -- -n PROCESS_COUNT to speed up with multi-processing
     pytest --cov=pipenv_setup {posargs}
 
 [testenv:py34]
@@ -22,6 +21,4 @@ deps =
 ; only run codecov on python 3.7
 [testenv:py37]
 commands =
-    ; tox -- -n PROCESS_COUNT to speed up with multi-processing
     pytest --cov=pipenv_setup --mypy {posargs}
-    codecov -e CODECOV_TOKEN


### PR DESCRIPTION
Codecov was in dev dependencies and ran only after tests on python3.7

Codecov is now dropped in dev dependencies. Codecov will be ran on travis only. Also it runs after build on each python version, covering python-version-dependent code.