### PR TITLE
specify colorama~=0.4

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ autopep8 = "~=1.4"
 [packages]
 pipfile = "~=0.0"
 black = {markers = "python_version>='3.6'",version = "==19.10b0"}
-colorama = "~=0.4.3"
+colorama = "~=0.4"
 packaging = "~=19.1"
 requirementslib = "~=1.5"
 vistir = "~=0.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6cb94a7ce5f61b4090d5ae00f031babdb1bd148c52e91f671b1573d9a81fa1f3"
+            "sha256": "9e4ea089cc5194e01a7ab7eea7f74c5055044f383b4ace73a1b7de7990fff986"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -311,11 +311,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:57147f6b0403b59f33fd357f169f860e031303415aeb7d04ede4839d23905ab8",
-                "sha256:7ae5ccaca427bafa9760ac3cd8f8c244bfc259794b5b6bb9db4dda2241575d09"
+                "sha256:b338014b9bc7102ca69e0fb96ed07215a8954d2989bc5d83658494ab2ba634af",
+                "sha256:e013e7800f60ec4dde789ebf4e9f7a54236e4bbf5df2a1a4e20ce9e1d9609d67"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         }
     },
     "develop": {
@@ -797,11 +797,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:57147f6b0403b59f33fd357f169f860e031303415aeb7d04ede4839d23905ab8",
-                "sha256:7ae5ccaca427bafa9760ac3cd8f8c244bfc259794b5b6bb9db4dda2241575d09"
+                "sha256:b338014b9bc7102ca69e0fb96ed07215a8954d2989bc5d83658494ab2ba634af",
+                "sha256:e013e7800f60ec4dde789ebf4e9f7a54236e4bbf5df2a1a4e20ce9e1d9609d67"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
     install_requires=[
         "pipfile~=0.0",
         "black==19.10b0; python_version >= '3.6'",
-        "colorama~=0.4.3",
+        "colorama~=0.4",
         "packaging~=19.1",
         "requirementslib~=1.5",
         "vistir~=0.4",


### PR DESCRIPTION
choice of `colorama~=0.4` was arbitrary

Signed-off-by: Bryant Finney <bryant@outdoorlinkinc.com>