### PR TITLE
Added -l/--lockfile flag to the check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ run `$ pipenv-setup check`
     (exits with 1)
     ```
 
+- provide `--lockfile` flag to check `setup.py` against `Pipfile.lock` instead of `Pipfile`
+
+    By default, `pipenv-setup check` compares the dependencies from `setup.py` against
+    the dependencies listed in `Pipfile`.  This works well for most cases, but there
+    are some exceptions that break this strategy, including (but not necessarily limited to):
+
+    * VCS dependencies with a mutable `ref` (e.g. - git branch name instead of a tag or commit sha)
+      * Because these resolve to an immutable pointer (e.g. - commit sha) in `setup.py`, the
+        dependency will no longer match between `setup.py` and `Pipfile`.  However, `Pipfile.lock`
+        will contain the same resolved pointer as `setup.py`.
+
+
 ## Contributing
 
 If you'd like to contribute to `pipenv-setup`, see [Contribution Guide](CONTRIBUTING.md)

--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -83,6 +83,14 @@ def cmd(argv=sys.argv):
         help="allow local packages in pipfile default packages",
     )
 
+    check_parser.add_argument(
+        "-l",
+        "--lockfile",
+        action="store_true",
+        help="check the dependencies from setup.py against Pipfile.lock instead of Pipfile."
+        " By default, the dependencies from setup.py are checked against the Pipfile.",
+    )
+
     if len(argv[1:]) == 0:
         parser.print_help()
     else:
@@ -134,9 +142,14 @@ def check(args):
     if not Path("setup.py").exists():
         fatal_error("setup.py not found")
 
-    local_packages, remote_packages = pipfile_parser.get_default_packages(
-        Path("Pipfile")
-    )
+    if args.lockfile:
+        local_packages, remote_packages = lockfile_parser.get_default_packages(
+            Path("Pipfile.lock")
+        )
+    else:
+        local_packages, remote_packages = pipfile_parser.get_default_packages(
+            Path("Pipfile")
+        )
 
     if local_packages and not args.ignore_local:
         package_names = ", ".join(local_packages)

--- a/tests/data/lockfile_vcs_branch_0/Pipfile
+++ b/tests/data/lockfile_vcs_branch_0/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+gitdir = "*"
+
+[packages]
+django = { git = 'https://github.com/django/django.git', ref = 'master' }
+
+[requires]
+python_version = "3.7"

--- a/tests/data/lockfile_vcs_branch_0/Pipfile.lock
+++ b/tests/data/lockfile_vcs_branch_0/Pipfile.lock
@@ -1,0 +1,40 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a7fb730effa11772acc36af98fa853226ccb3126431e0a8379b242edea8cd24b"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "django": {
+            "git": "https://github.com/django/django.git",
+            "ref": "a92cc84b4a206d18a5f1a0eaa47f19add40ff99b"
+        }
+    },
+    "develop": {
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "version": "==0.4.3"
+        },
+        "gitdir": {
+            "hashes": [
+                "sha256:e53954d11d238e06fa3d862b0e6acacb29bfd3ad7c9f56f5ca95303eb67b6815"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
+        }
+    }
+}

--- a/tests/data/lockfile_vcs_branch_0/setup.py
+++ b/tests/data/lockfile_vcs_branch_0/setup.py
@@ -1,0 +1,190 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/guides/distributing-packages-using-setuptools/
+https://github.com/pypa/sampleproject
+Modified by Madoshakalaka@Github (dependency links added)
+"""
+
+# io.open is needed for projects that support Python 2.7
+# It ensures open() defaults to text mode with universal newlines,
+# and accepts an argument to specify the text encoding
+# Python 3 only projects can skip this import
+from io import open
+from os import path
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
+# Arguments marked as "Required" below must be included for upload to PyPI.
+# Fields marked as "Optional" may be commented out.
+
+setup(
+    extras_require={"dev": ["colorama==0.4.3", "gitdir==1.2.2",]},
+    # This is the name of your project. The first time you publish this
+    # package, this name will be registered for you. It will determine how
+    # users can install this project, e.g.:
+    #
+    # $ pip install sampleproject
+    #
+    # And where it will live on PyPI: https://pypi.org/project/sampleproject/
+    #
+    # There are some restrictions on what makes a valid project name
+    # specification here:
+    # https://packaging.python.org/specifications/core-metadata/#name
+    name="sampleproject",  # Required
+    # Versions should comply with PEP 440:
+    # https://www.python.org/dev/peps/pep-0440/
+    #
+    # For a discussion on single-sourcing the version across setup.py and the
+    # project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version="0.0.0",  # Required
+    # This is a one-line description or tagline of what your project does. This
+    # corresponds to the "Summary" metadata field:
+    # https://packaging.python.org/specifications/core-metadata/#summary
+    description="A sample Python project",  # Optional
+    # This is an optional longer description of your project that represents
+    # the body of text which users will see when they visit PyPI.
+    #
+    # Often, this is the same as your README, so you can just read it in from
+    # that file directly (as we have already done above)
+    #
+    # This field corresponds to the "Description" metadata field:
+    # https://packaging.python.org/specifications/core-metadata/#description-optional
+    long_description=long_description,  # Optional
+    # Denotes that our long_description is in Markdown; valid values are
+    # text/plain, text/x-rst, and text/markdown
+    #
+    # Optional if long_description is written in reStructuredText (rst) but
+    # required for plain-text or Markdown; if unspecified, "applications should
+    # attempt to render [the long_description] as text/x-rst; charset=UTF-8 and
+    # fall back to text/plain if it is not valid rst" (see link below)
+    #
+    # This field corresponds to the "Description-Content-Type" metadata field:
+    # https://packaging.python.org/specifications/core-metadata/#description-content-type-optional
+    long_description_content_type="text/markdown",  # Optional (see note above)
+    # This should be a valid link to your project's main homepage.
+    #
+    # This field corresponds to the "Home-Page" metadata field:
+    # https://packaging.python.org/specifications/core-metadata/#home-page-optional
+    url="https://github.com/pypa/sampleproject",  # Optional
+    # This should be your name or the name of the organization which owns the
+    # project.
+    author="The Python Packaging Authority",  # Optional
+    # This should be a valid email address corresponding to the author listed
+    # above.
+    author_email="pypa-dev@googlegroups.com",  # Optional
+    # Classifiers help users find your project by categorizing it.
+    #
+    # For a list of valid classifiers, see https://pypi.org/classifiers/
+    classifiers=[  # Optional
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        "Development Status :: 3 - Alpha",
+        # Indicate who your project is intended for
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
+        # Pick your license as you wish
+        "License :: OSI Approved :: MIT License",
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        # These classifiers are *not* checked by 'pip install'. See instead
+        # 'python_requires' below.
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    # This field adds keywords for your project which will appear on the
+    # project page. What does your project relate to?
+    #
+    # Note that this is a string of words separated by whitespace, not a list.
+    keywords="sample setuptools development",  # Optional
+    # You can just specify package directories manually here if your project is
+    # simple. Or you can use find_packages().
+    #
+    # Alternatively, if you just want to distribute a single Python file, use
+    # the `py_modules` argument instead as follows, which will expect a file
+    # called `my_module.py` to exist:
+    #
+    #   py_modules=["my_module"],
+    #
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),  # Required
+    # Specify which Python versions you support. In contrast to the
+    # 'Programming Language' classifiers above, 'pip install' will check this
+    # and refuse to install the project if the version does not match. If you
+    # do not support Python 2, you can simplify this to '>=3.5' or similar, see
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+    # This field lists other packages that your project depends on to run.
+    # Any package you put here will be installed by pip when your project is
+    # installed, so they must be valid existing projects.
+    #
+    # For an analysis of "install_requires" vs pip's requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[],  # Optional
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). Users will be able to install these using the "extras"
+    # syntax, for example:
+    #
+    #   $ pip install sampleproject[dev]
+    #
+    # Similar to `install_requires` above, these must be valid existing
+    # projects.
+    # extras_require={"dev": []},  # Optional
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.
+    #
+    # Sometimes you’ll want to use packages that are properly arranged with
+    # setuptools, but are not published to PyPI. In those cases, you can specify
+    # a list of one or more dependency_links URLs where the package can
+    # be downloaded, along with some additional hints, and setuptools
+    # will find and install the package correctly.
+    # see https://python-packaging.readthedocs.io/en/latest/dependencies.html#packages-not-on-pypi
+    #
+    dependency_links=[
+        "git+https://github.com/django/django.git@a92cc84b4a206d18a5f1a0eaa47f19add40ff99b#egg=django"
+    ],
+    # If using Python 2.6 or earlier, then these have to be included in
+    # MANIFEST.in as well.
+    # package_data={"sample": ["package_data.dat"]},  # Optional
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
+    #
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    # data_files=[("my_data", ["data/data_file"])],  # Optional
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # `pip` to create the appropriate form of executable for the target
+    # platform.
+    #
+    # For example, the following would provide a command called `sample` which
+    # executes the function `main` from this package when invoked:
+    # entry_points={"console_scripts": ["sample=sample:main"]},  # Optional
+    # List additional URLs that are relevant to your project as a dict.
+    #
+    # This field corresponds to the "Project-URL" metadata fields:
+    # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
+    #
+    # Examples listed include a pattern for specifying where the package tracks
+    # issues, where the source is hosted, where to say thanks to the package
+    # maintainers, and where to support the project financially. The key is
+    # what's used to render the link text on PyPI.
+    project_urls={  # Optional
+        "Bug Reports": "https://github.com/pypa/sampleproject/issues",
+        "Funding": "https://donate.pypi.org",
+        "Say Thanks!": "http://saythanks.io/to/example",
+        "Source": "https://github.com/pypa/sampleproject/",
+    },
+)


### PR DESCRIPTION
## Problem

There are some cases where `pipenv-setup check` can fail for otherwise valid (IMO) cases.  This feels like a potentially generic problem, but I've only stumbled across one case so far:

* VCS dependencies with branches as their `ref` (e.g. - `ref = "master"` instead of `ref = "1.11.4"`)

See the README updates and test cases for more details.  

## Proposed Solution

This PR contains one of several different ways that could fix my current issue.  By checking `setup.py` against `Pipfile.lock`, the idea is to check against the actual source-of-truth from which `setup.py` was generated in the first place, which I personally think is a better idea always, but I put it behind a flag so as not to introduce a potentially breaking change.

Feedback welcome!