### PR TITLE
Ignore typing when python_version >= 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
         "vistir~=0.4",
         "autopep8~=1.4; python_version < '3.6'",
         "six~=1.12",
-        "typing~=3.7",
+        "typing~=3.7; python_version < '3.7'",
     ],  # Optional
     entry_points={
         "console_scripts": ["pipenv-setup=pipenv_setup.main:cmd"]


### PR DESCRIPTION
## Problem

Certain interactions with libs in Python 3.7 and the `typing` backport don't play nicely.  As an example, newer versions of `pip` can't install VCS dependencies when the `typing` backport is present in Python 3.7:

```
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

## Reproduce

### Environment
* **Python Version:** `3.7.7`
* **Pip Version:** `20.1.1`
* **Pipenv version:** `2020.5.28`

### Steps
1. Create new project with provided `Pipfile`:
   ```pipfile
   [[source]]
   url = "https://pypi.org/simple"
   verify_ssl = true
   name = "pypi"

   [requires]
   python_version = "3.7"

   [packages]
   pipenv-setup = "*"
   celery = { git = "https://github.com/celery/celery", ref = "master" }
   ```
2. Create/update lockfile and sync dependencies
   ```bash
   pipenv lock
   pipenv sync
   ``` 
3. Sync will fail b/c pip gets tripped up on the `typing` backport:
   ```
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/cli/command.py", line 689, in sync
   [InstallError]:       pypi_mirror=state.pypi_mirror,
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/core.py", line 2900, in do_sync
   [InstallError]:       system=system,
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/core.py", line 1317, in do_init
   [InstallError]:       pypi_mirror=pypi_mirror,
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/core.py", line 906, in do_install_dependencies
   [InstallError]:       retry_list, procs, failed_deps_queue, requirements_dir, **install_kwargs
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/core.py", line 801, in batch_install
   [InstallError]:       _cleanup_procs(procs, failed_deps_queue, retry=retry)
   [InstallError]:   File "/Users/rsnyder/.pyenv/versions/3.7.1/lib/python3.7/site-packages/pipenv/core.py", line 708, in _cleanup_procs
   [InstallError]:       raise exceptions.InstallError(c.dep.name, extra=err_lines)
   [pipenv.exceptions.InstallError]: Collecting celery
   [pipenv.exceptions.InstallError]:   Cloning https://github.com/celery/celery (to revision 364bb290d753a0c3c0e07b08c49adf3334ba2da3) to /private/var/folders/1h/c2z3qn417jq4vlhmmr6f126h0000gn/T/pip-install-d_a7zssv/celery
   [pipenv.exceptions.InstallError]:   Installing build dependencies: started
   [pipenv.exceptions.InstallError]:   Installing build dependencies: finished with status 'error'
   [pipenv.exceptions.InstallError]: Running command git clone -q https://github.com/celery/celery /private/var/folders/1h/c2z3qn417jq4vlhmmr6f126h0000gn/T/pip-install-d_a7zssv/celery
   [pipenv.exceptions.InstallError]:   ERROR: Command errored out with exit status 1:
   [pipenv.exceptions.InstallError]:    command: /Users/rsnyder/.ve/dp2-hICnNtbL/bin/python /Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /private/var/folders/1h/c2z3qn417jq4vlhmmr6f126h0000gn/T/pip-build-env-frv0j14_/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
   [pipenv.exceptions.InstallError]:        cwd: None
   [pipenv.exceptions.InstallError]:   Complete output (44 lines):
   [pipenv.exceptions.InstallError]:   Traceback (most recent call last):
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.pyenv/versions/3.7.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
   [pipenv.exceptions.InstallError]:       "__main__", mod_spec)
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.pyenv/versions/3.7.7/lib/python3.7/runpy.py", line 85, in _run_code
   [pipenv.exceptions.InstallError]:       exec(code, run_globals)
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/__main__.py", line 26, in <module>
   [pipenv.exceptions.InstallError]:       sys.exit(_main())
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/cli/main.py", line 73, in main
   [pipenv.exceptions.InstallError]:       command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/commands/__init__.py", line 104, in create_command
   [pipenv.exceptions.InstallError]:       module = importlib.import_module(module_path)
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.pyenv/versions/3.7.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
   [pipenv.exceptions.InstallError]:       return _bootstrap._gcd_import(name[level:], package, level)
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
   [pipenv.exceptions.InstallError]:     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 24, in <module>
   [pipenv.exceptions.InstallError]:       from pip._internal.cli.req_command import RequirementCommand, with_cleanup
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 16, in <module>
   [pipenv.exceptions.InstallError]:       from pip._internal.index.package_finder import PackageFinder
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/index/package_finder.py", line 21, in <module>
   [pipenv.exceptions.InstallError]:       from pip._internal.index.collector import parse_links
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_internal/index/collector.py", line 14, in <module>
   [pipenv.exceptions.InstallError]:       from pip._vendor import html5lib, requests
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_vendor/requests/__init__.py", line 114, in <module>
   [pipenv.exceptions.InstallError]:       from . import utils
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_vendor/requests/utils.py", line 25, in <module>
   [pipenv.exceptions.InstallError]:       from . import certs
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_vendor/requests/certs.py", line 15, in <module>
   [pipenv.exceptions.InstallError]:       from pip._vendor.certifi import where
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_vendor/certifi/__init__.py", line 1, in <module>
   [pipenv.exceptions.InstallError]:       from .core import contents, where
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip/_vendor/certifi/core.py", line 12, in <module>
   [pipenv.exceptions.InstallError]:       from importlib.resources import read_text
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.pyenv/versions/3.7.7/lib/python3.7/importlib/resources.py", line 11, in <module>
   [pipenv.exceptions.InstallError]:       from typing import Iterable, Iterator, Optional, Set, Union   # noqa: F401
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/typing.py", line 1357, in <module>
   [pipenv.exceptions.InstallError]:       class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
   [pipenv.exceptions.InstallError]:     File "/Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/typing.py", line 1005, in __new__
   [pipenv.exceptions.InstallError]:       self._abc_registry = extra._abc_registry
   [pipenv.exceptions.InstallError]:   AttributeError: type object 'Callable' has no attribute '_abc_registry'
   [pipenv.exceptions.InstallError]:   ----------------------------------------
   [pipenv.exceptions.InstallError]: ERROR: Command errored out with exit status 1: /Users/rsnyder/.ve/dp2-hICnNtbL/bin/python /Users/rsnyder/.ve/dp2-hICnNtbL/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /private/var/folders/1h/c2z3qn417jq4vlhmmr6f126h0000gn/T/pip-build-env-frv0j14_/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel Check the logs for full command output.
   ERROR: Couldn't install package: celery
    Package installation failed...
   ```

## Reason

This issue is known to occur when importing a backport instead of the stdlib typing module in python 3.7. (Reference: [python typing module](https://docs.python.org/3.7/library/typing.html))

> `typing` is in the standard library since 3.5.

## Solution

Ignore `typing` at install_requires when `python_version` is 3.7 (or both of 3.7 and 3.6).

## References

Pulling from collective wisdom of GitHub on similar issues:

* https://github.com/aws/chalice/issues/1050
* https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues/49
* https://github.com/zulip/zulip-terminal/pull/196