### PR TITLE
deprecate dependency_links unless --use-dependency-links specified

### DIFF
--- a/pipenv_setup/main.py
+++ b/pipenv_setup/main.py
@@ -62,6 +62,12 @@ def cmd(argv=sys.argv):
         help="provide this flag to also sync development packages to extras [dev] in setup.py",
     )
 
+    sync_parser.add_argument(
+        "--use-dependency-links",
+        action="store_true",
+        help="write vcs dependencies to deprecated dependency_links field instead of install_requires"
+    )
+
     check_parser = subparsers.add_parser(
         "check",
         help="check whether Pipfile is consistent with setup.py.\n"
@@ -243,7 +249,9 @@ def sync(argv):
         for remote_package_name, remote_package_config in remote_packages.items():
             try:
                 destination_kw, value = parser.format_remote_package(
-                    remote_package_name, remote_package_config
+                    remote_package_name,
+                    remote_package_config,
+                    use_dependency_links=argv.use_dependency_links,
                 )
             except ValueError as e:
                 fatal_error(
@@ -266,7 +274,10 @@ def sync(argv):
             ) in dev_remote_packages.items():
 
                 destination_kw, value = parser.format_remote_package(
-                    remote_package_name, remote_package_config, dev=True
+                    remote_package_name,
+                    remote_package_config,
+                    dev=True,
+                    use_dependency_links=argv.use_dependency_links,
                 )
                 dev_package_success_count += 1
                 dependency_arguments[destination_kw].append(value)

--- a/pipenv_setup/pipfile_parser.py
+++ b/pipenv_setup/pipfile_parser.py
@@ -8,14 +8,15 @@ from pipenv_setup.constants import PipfileConfig, vcs_list
 
 
 def format_remote_package(
-    package_name, config, dev=False
-):  # type: (str, PipfileConfig, bool) -> Tuple[str, str]
+    package_name, config, dev=False, use_dependency_links=False
+):  # type: (str, PipfileConfig, bool, bool) -> Tuple[str, str]
     """
     format and return a string that can be put into either install_requires or dependency_links or extras_require
 
     :param package_name:
     :param config:
     :param dev: is package a development package
+    :param use_dependency_links: use deprecated dependency_links field
     :return: Tuple[keyword_target, list_argument]
     :raise ValueError: if a package config is not understood
     """
@@ -31,7 +32,10 @@ def format_remote_package(
         # https://setuptools.readthedocs.io/en/latest/setuptools.html#dependencies-that-aren-t-in-pypi
         if "file" in config:  # remote built distribution '.zip' file for example
             assert isinstance(config, dict)
-            return "dependency_links", config["file"]
+            if use_dependency_links:
+                return "dependency_links", config["file"]
+            else:
+                return "install_requires", config["file"]
         if is_pypi_package(config):  # pypi package
             return (
                 "install_requires",
@@ -58,8 +62,13 @@ def format_remote_package(
             link = "{vcs}+{link}".format(vcs=vcs, link=config[vcs])
             if "ref" in config:
                 link += "@" + config["ref"]
-            link += "#egg=" + package_name
-            return "dependency_links", link
+
+            if use_dependency_links:
+                link += "#egg=" + package_name
+                return "dependency_links", link
+            else:
+                link = "{package_name} @ {link}".format(package_name=package_name, link=link)
+                return "install_requires", link
 
 
 def is_vcs_package(config):  # type: (PipfileConfig) -> bool

--- a/pipenv_setup/setup_parser.py
+++ b/pipenv_setup/setup_parser.py
@@ -3,13 +3,10 @@ from typing import List, Optional, Tuple
 
 
 def get_kw_list_of_string_arg(setup_text, kw_name):  # type: (str, str) -> List[str]
-    """
-    :raise TypeError ValueError: when failed to get a list of strings
-    """
     root_node = ast.parse(setup_text)
     kw_list_node = get_kw_list_node(root_node, kw_name)
     if kw_list_node is None:
-        raise ValueError("keyword argument %s not found" % kw_name)
+        return None
     return parse_list_of_string(kw_list_node)
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -40,7 +40,7 @@ def compare_list_of_string_kw_arg(
     """
     args_a = setup_parser.get_kw_list_of_string_arg(setup_text_a, kw_name)
     args_b = setup_parser.get_kw_list_of_string_arg(setup_text_b, kw_name)
-    if ordering_matters:
+    if ordering_matters or args_a is None or args_b is None:
         return args_a == args_b
     else:
         return set(args_a) == set(args_b)

--- a/tests/pipfile_parser_test.py
+++ b/tests/pipfile_parser_test.py
@@ -1,16 +1,8 @@
-from pipenv_setup import lockfile_parser
-
-
-def test_get_dev_dependencies(shared_datadir):
-    local, remote = lockfile_parser.get_dev_packages(
-        shared_datadir / "generic_nice_0" / "Pipfile.lock"
-    )
-    assert "generic-package" in local
-    assert "gitdir" in remote
+from pipenv_setup import pipfile_parser
 
 
 def test_use_dependency_links_vcs_disabled(shared_datadir):
-    destination_kw, value = lockfile_parser.format_remote_package(
+    destination_kw, value = pipfile_parser.format_remote_package(
         "django",
         {"git": "https://github.com/django/django.git"},
     )
@@ -19,7 +11,7 @@ def test_use_dependency_links_vcs_disabled(shared_datadir):
 
 
 def test_use_dependency_links_vcs_enabled(shared_datadir):
-    destination_kw, value = lockfile_parser.format_remote_package(
+    destination_kw, value = pipfile_parser.format_remote_package(
         "django",
         {"git": "https://github.com/django/django.git"},
         use_dependency_links=True,
@@ -29,7 +21,7 @@ def test_use_dependency_links_vcs_enabled(shared_datadir):
 
 
 def test_use_dependency_links_file_disabled(shared_datadir):
-    destination_kw, value = lockfile_parser.format_remote_package(
+    destination_kw, value = pipfile_parser.format_remote_package(
         "e682b37",
         {"file": "https://github.com/divio/django-cms/archive/release/3.4.x.zip"},
     )
@@ -38,7 +30,7 @@ def test_use_dependency_links_file_disabled(shared_datadir):
 
 
 def test_use_dependency_links_file_enabled(shared_datadir):
-    destination_kw, value = lockfile_parser.format_remote_package(
+    destination_kw, value = pipfile_parser.format_remote_package(
         "e682b37",
         {"file": "https://github.com/divio/django-cms/archive/release/3.4.x.zip"},
         use_dependency_links=True,


### PR DESCRIPTION
Pip removed support for `dependency_links` in 19.0 (https://github.com/pypa/pip/issues/6060). This PR modifies the `sync` command to write dependencies to `install_requires` using PEP 508 URLs, unless `--use-dependency-links` is specified.