### PR TITLE
Do not pin black to avoid conflict with consumers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ autopep8 = "~=1.4"
 
 [packages]
 pipfile = "~=0.0"
-black = {markers = "python_version>='3.6'",version = "==19.10b0"}
+black = "*"
 colorama = "~=0.4"
 packaging = "~=20.0"
 requirementslib = "~=1.5"
@@ -28,3 +28,6 @@ typing = {markers = "python_version<'3.7'", version = "~=3.7"}
 # use this to sync this pipfile to setup.py, explained in CONTRIBUTING.md
 # `$ pipenv run sync-deps`
 sync-deps = 'python -m pipenv_setup sync --dev --pipfile'
+
+[pipenv]
+allow_prereleases = true

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     },
     install_requires=[
         "pipfile~=0.0",
-        "black==19.10b0; python_version >= '3.6'",
+        "black",
         "colorama~=0.4",
         "packaging~=20.0",
         "requirementslib~=1.5",


### PR DESCRIPTION
This was forcing us to use an older version of black. Also, because black is still in pre-release, had to add `allow_prereleases` to `Pipfile`. 

Alternatively, since the code is written to fallback to autopep8 if `import black` fails, we could just remove the dependency on black entirely.