### PR TITLE
Fixed assertion error when running pipenv-setup check

### DIFF
--- a/pipenv_setup/lockfile_parser.py
+++ b/pipenv_setup/lockfile_parser.py
@@ -1,6 +1,14 @@
 from typing import Tuple, Dict
 
-from requirementslib import Lockfile, Requirement
+try:
+    from requirementslib import Lockfile
+except AssertionError:
+    import os
+
+    os.environ["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
+    from requirementslib import Lockfile
+
+from requirementslib import Requirement
 from vistir.compat import Path
 
 from pipenv_setup.constants import LockConfig


### PR DESCRIPTION
Solves #101 by adding `SETUPTOOLS_USE_DISTUTILS=stdlib` in the current environment if the `from requirementslib import Lockfile` import fails